### PR TITLE
Switch from alpine to scratch base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:latest as downloader
 
 ARG PB_VERSION=0.16.5
 
@@ -9,6 +9,10 @@ RUN apk add --no-cache \
 # download and unzip PocketBase
 ADD https://github.com/pocketbase/pocketbase/releases/download/v${PB_VERSION}/pocketbase_${PB_VERSION}_linux_amd64.zip /tmp/pb.zip
 RUN unzip /tmp/pb.zip -d /pb/
+
+FROM scratch
+
+COPY --from=downloader /pb/pocketbase /pb/pocketbase
 
 EXPOSE 8080
 


### PR DESCRIPTION
This change would reduce the attack surface and the docker image size by switching from alpine to scratch:
- alpine: 71.3MB
- scratch: 47.5MB