### PR TITLE
Update PB_VERSION to 0.30.4 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-ARG PB_VERSION=0.30.0
+ARG PB_VERSION=0.30.4
 
 RUN apk add --no-cache \
     unzip \


### PR DESCRIPTION
This pull request updates the version of the `PB_VERSION` build argument in the `Dockerfile` to use a newer release.