### PR TITLE
Add and mount pb_hooks and pb_public directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apk add --no-cache \
 # download and unzip PocketBase
 ADD https://github.com/pocketbase/pocketbase/releases/download/v${PB_VERSION}/pocketbase_${PB_VERSION}_linux_amd64.zip /tmp/pb.zip
 RUN unzip /tmp/pb.zip -d /pb/
+COPY pb_hooks /pb/pb_hooks
+COPY pb_public /pb/pb_public
 
 EXPOSE 8080
 

--- a/pb_hooks/main.pb.js
+++ b/pb_hooks/main.pb.js
@@ -1,0 +1,5 @@
+routerAdd("GET", "/hello", (e) => {
+  let name = e.request.url.query().get("name") || "Person";
+
+  return e.json(200, { message: "Hello " + name });
+});

--- a/pb_public/index.html
+++ b/pb_public/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hello World - PocketBase</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: #333;
+        }
+        
+        .container {
+            background: white;
+            padding: 3rem;
+            border-radius: 12px;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+            text-align: center;
+            max-width: 600px;
+        }
+        
+        h1 {
+            font-size: 3rem;
+            margin-bottom: 1rem;
+            color: #667eea;
+        }
+        
+        p {
+            font-size: 1.2rem;
+            color: #666;
+            margin-top: 1rem;
+        }
+        
+        .status {
+            display: inline-block;
+            margin-top: 2rem;
+            padding: 0.5rem 1.5rem;
+            background: #10b981;
+            color: white;
+            border-radius: 6px;
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Hello World!</h1>
+        <p>PocketBase is successfully serving this page.</p>
+        <div class="status">✓ Server is running</div>
+    </div>
+</body>
+</html>
+


### PR DESCRIPTION
This is a simple addition to show that pb_hooks and pb_public directories can be mounted in the Dockerfile. This helps show more capabilities of PocketBase. To test these after deployment visiting the root of your deployed service via its public URL should show a simple Hello World page. Additionally hitting the `/hello` (or `/hello?name=Jim`) endpoint should demo adding a simple route with a JSON response.

<img width="1074" height="784" alt="image" src="https://github.com/user-attachments/assets/36a84ddd-8704-477c-8721-3132d3f59819" />


<img width="1074" height="784" alt="image" src="https://github.com/user-attachments/assets/30e36c81-60a3-4312-9340-ff0ec999e59c" />
